### PR TITLE
Add ability to check for formatting during the compile lifecycle phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,27 @@ If you prefer, you can only check formatting at build time using the `check` goa
     </build>
 ```
 
+If you prefer, you can only check formatting at build time during the maven `compile` phase using the `early-check` goal:
+
+```xml
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.9</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>early-check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+```
+
 ### Options
 
 `sourceDirectory` represents the directory where your Java sources that need to be formatted are contained. It defaults to `${project.build.sourceDirectory}`

--- a/src/main/java/com/coveo/EarlyCheck.java
+++ b/src/main/java/com/coveo/EarlyCheck.java
@@ -1,0 +1,87 @@
+package com.coveo;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.lang.String.format;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Early check mojo that will ensure all files are formatted. If some files are not formatted, an
+ * exception is thrown. This will be done at the compilation stage so that the build fails early.
+ */
+@Mojo(name = "early-check", defaultPhase = LifecyclePhase.COMPILE, threadSafe = true)
+public class EarlyCheck extends AbstractFMT {
+
+  /** Flag to display or not the files that are not compliant. */
+  @Parameter(defaultValue = "true", property = "displayFiles")
+  private boolean displayFiles;
+
+  /** Limit the number of non-complying files to display */
+  @Parameter(defaultValue = "100", property = "displayLimit")
+  private int displayLimit;
+
+  /** List of unformatted files. */
+  private List<String> filesNotFormatted = new ArrayList<String>();
+
+  /**
+   * Post Execute action. It is called at the end of the execute method. Subclasses can add extra
+   * checks.
+   *
+   * @param filesProcessed the list of processed files by the formatter
+   * @param nonComplyingFiles the number of files that are not compliant
+   * @throws MojoFailureException if there is an exception
+   */
+  @Override
+  protected void postExecute(List<String> filesProcessed, int nonComplyingFiles)
+      throws MojoFailureException {
+    if (nonComplyingFiles > 0) {
+      String message = "Found " + nonComplyingFiles + " non-complying files, failing build";
+      getLog().error(message);
+      getLog().error("To fix formatting errors, run \"mvn com.coveo:fmt-maven-plugin:format\"");
+      // do not support limit < 1
+      displayLimit = max(1, displayLimit);
+
+      // Display first displayLimit files not formatted
+      if (displayFiles) {
+        for (String path :
+            filesNotFormatted.subList(0, min(displayLimit, filesNotFormatted.size()))) {
+          getLog().error("Non complying file: " + path);
+        }
+
+        if (nonComplyingFiles > displayLimit) {
+          getLog().error(format("... and %d more files.", nonComplyingFiles - displayLimit));
+        }
+      }
+      throw new MojoFailureException(message);
+    }
+  }
+
+  /**
+   * Hook called when the processd file is not compliant with the formatter.
+   *
+   * @param file the file that is not compliant
+   * @param formatted the corresponding formatted of the file.
+   */
+  @Override
+  protected void onNonComplyingFile(final File file, final String formatted) throws IOException {
+    filesNotFormatted.add(file.getAbsolutePath());
+  }
+
+  /**
+   * Provides the name of the label used when a non-formatted file is found.
+   *
+   * @return the label to use in the log
+   */
+  @Override
+  protected String getProcessingLabel() {
+    return "non-complying";
+  }
+}

--- a/src/test/java/com/coveo/FMTTest.java
+++ b/src/test/java/com/coveo/FMTTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 public class FMTTest {
   private static String FORMAT = "format";
   private static String CHECK = "check";
+  private static String EARLY_CHECK = "early-check";
 
   @Rule public MojoRule mojoRule = new MojoRule();
 
@@ -160,6 +161,57 @@ public class FMTTest {
   public void checkSucceedsWhenNotFormattedButIgnored() throws Exception {
     Check check =
         (Check) mojoRule.lookupConfiguredMojo(loadPom("check_notformatted_ignored"), CHECK);
+    check.execute();
+  }
+
+  @Test(expected = MojoFailureException.class)
+  public void validateOnlyFailsWhenNotFormattedEarlyCheck() throws Exception {
+    EarlyCheck check =
+        (EarlyCheck)
+            mojoRule.lookupConfiguredMojo(loadPom("validateonly_notformatted"), EARLY_CHECK);
+    check.execute();
+  }
+
+  @Test
+  public void validateOnlySucceedsWhenFormattedEarlyCheck() throws Exception {
+    EarlyCheck check =
+        (EarlyCheck) mojoRule.lookupConfiguredMojo(loadPom("validateonly_formatted"), EARLY_CHECK);
+    check.execute();
+  }
+
+  @Test(expected = MojoFailureException.class)
+  public void withUnusedImportsEarlyCheck() throws Exception {
+    EarlyCheck check =
+        (EarlyCheck) mojoRule.lookupConfiguredMojo(loadPom("importunused"), EARLY_CHECK);
+    check.execute();
+  }
+
+  @Test(expected = MojoFailureException.class)
+  public void withUnsortedImportsEarlyCheck() throws Exception {
+    EarlyCheck check =
+        (EarlyCheck) mojoRule.lookupConfiguredMojo(loadPom("importunsorted"), EARLY_CHECK);
+    check.execute();
+  }
+
+  @Test(expected = MojoFailureException.class)
+  public void checkFailsWhenNotFormattedEarlyCheck() throws Exception {
+    EarlyCheck check =
+        (EarlyCheck) mojoRule.lookupConfiguredMojo(loadPom("check_notformatted"), EARLY_CHECK);
+    check.execute();
+  }
+
+  @Test
+  public void checkSucceedsWhenFormattedEarlyCheck() throws Exception {
+    EarlyCheck check =
+        (EarlyCheck) mojoRule.lookupConfiguredMojo(loadPom("check_formatted"), EARLY_CHECK);
+    check.execute();
+  }
+
+  @Test
+  public void checkSucceedsWhenNotFormattedButIgnoredEarlyCheck() throws Exception {
+    EarlyCheck check =
+        (EarlyCheck)
+            mojoRule.lookupConfiguredMojo(loadPom("check_notformatted_ignored"), EARLY_CHECK);
     check.execute();
   }
 


### PR DESCRIPTION
If there are non-complying files, `check` fails the build after all of the previous phases are completed, which often involves running several tests. In order to save time, `early-check` performs the same operations as `check` but during the `compile` lifecycle phase.