### PR TITLE
Suggest google-java-format integration for IDE's

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,7 @@ Formats your code using [google-java-format](https://github.com/google/google-ja
 
 The format cannot be configured by design.
 
-If you want your IDE to stick to the same format, check out [the available configuration files](https://github.com/google/styleguide)
-
-* [Eclipse](https://github.com/google/styleguide/blob/gh-pages/eclipse-java-google-style.xml)
-* [IntelliJ IDEA](https://github.com/google/styleguide/blob/gh-pages/intellij-java-google-style.xml)
+If you want your IDE to stick to the same format, google-java-format also includes integrations for IntelliJ and Eclipse IDE's, following the installation instructions on the [README](https://github.com/google/google-java-format/blob/master/README.md#using-the-formatter).
 
 ## Usage
 


### PR DESCRIPTION
Instead of linking to Google Style-compliant configurations for those IDEs.

The behavior of, e.g.: Eclipse configured with `GoogleStyle` and `google-java-format` are subtly different in ways that can cause confusion (see google/google-java-format#504). Using the normal integration of the plugin will ensure consistent formatting in the IDE and the format plugin here.