### PR TITLE
fix: less verbose

### DIFF
--- a/src/main/java/com/coveo/AbstractFMT.java
+++ b/src/main/java/com/coveo/AbstractFMT.java
@@ -202,7 +202,9 @@ public abstract class AbstractFMT extends AbstractMojo {
   private boolean formatSourceFile(
       File file, Formatter formatter, JavaFormatterOptions.Style style) {
     if (file.isDirectory()) {
-      getLog().info("File '" + file + "' is a directory. Skipping.");
+      if (verbose) {
+        getLog().debug("File '" + file + "' is a directory. Skipping.");
+      }
       return true;
     }
 


### PR DESCRIPTION
do not log `File 'path' is a directory. Skipping.` for every sub directory if not verbose.