### PR TITLE
Upgrade Google Java Format 1.10.0 -> 1.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>com.google.googlejavaformat</groupId>
             <artifactId>google-java-format</artifactId>
-            <version>1.10.0</version>
+            <version>1.11.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This upgrade improves support for Java 17 syntax.

See:
- https://github.com/google/google-java-format/releases/tag/v1.11.0
- https://github.com/google/google-java-format/compare/v1.10.0...v1.11.0