### PR TITLE
Backport verboness reduction to 2.9.x and release 2.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To have your sources automatically formatted on each build, add to your pom.xml:
             <plugin>
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.9</version>
+                <version>2.9.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -46,7 +46,7 @@ If you prefer, you can only check formatting at build time using the `check` goa
             <plugin>
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.9</version>
+                <version>2.9.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -84,7 +84,7 @@ example:
         <plugin>
             <groupId>com.coveo</groupId>
             <artifactId>fmt-maven-plugin</artifactId>
-            <version>2.9</version>
+            <version>2.9.1</version>
             <configuration>
                 <sourceDirectory>some/source/directory</sourceDirectory>
                 <testSourceDirectory>some/test/directory</testSourceDirectory>
@@ -127,7 +127,7 @@ example to not display the non-compliant files:
         <plugin>
             <groupId>com.coveo</groupId>
             <artifactId>fmt-maven-plugin</artifactId>
-            <version>2.9</version>
+            <version>2.9.1</version>
             <configuration>
                 <displayFiles>false</displayFiles>
             </configuration>
@@ -150,7 +150,7 @@ example to limit the display up to 10 files
         <plugin>
             <groupId>com.coveo</groupId>
             <artifactId>fmt-maven-plugin</artifactId>
-            <version>2.9</version>
+            <version>2.9.1</version>
             <configuration>
                 <displayLimit>10</displayLimit>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>fmt-maven-plugin</artifactId>
-    <version>2.9.1</version>
+    <version>2.9.2</version>
     <packaging>maven-plugin</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>fmt-maven-plugin</artifactId>
-    <version>2.9</version>
+    <version>2.9.1</version>
     <packaging>maven-plugin</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/coveo/AbstractFMT.java
+++ b/src/main/java/com/coveo/AbstractFMT.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -73,6 +72,7 @@ public abstract class AbstractFMT extends AbstractMojo {
    *
    * @throws org.apache.maven.plugin.MojoExecutionException if any.
    */
+  @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     if (skip) {
       getLog().info("Skipping format check");
@@ -85,7 +85,7 @@ public abstract class AbstractFMT extends AbstractMojo {
     if (skipSortingImports) {
       getLog().info("Skipping sorting imports");
     }
-    List<File> directoriesToFormat = new ArrayList<File>();
+    List<File> directoriesToFormat = new ArrayList<>();
     if (sourceDirectory.exists()) {
       directoriesToFormat.add(sourceDirectory);
     } else {
@@ -145,14 +145,22 @@ public abstract class AbstractFMT extends AbstractMojo {
     try (Stream<Path> paths = Files.walk(Paths.get(directory.getPath()))) {
       FileFilter fileNameFilter = getFileNameFilter();
       FileFilter pathFilter = getPathFilter();
-      paths
-          .collect(Collectors.toList())
-          .parallelStream()
-          .filter(Files::isRegularFile)
-          .map(Path::toFile)
-          .filter(fileNameFilter::accept)
-          .filter(pathFilter::accept)
-          .forEach(file -> formatSourceFile(file, formatter));
+      long failures =
+          paths
+              .collect(Collectors.toList())
+              .parallelStream()
+              .filter(p -> p.toFile().exists())
+              .map(Path::toFile)
+              .filter(fileNameFilter::accept)
+              .filter(pathFilter::accept)
+              .map(file -> formatSourceFile(file, formatter))
+              .filter(r -> !r)
+              .count();
+
+      if (failures > 0) {
+        throw new MojoFailureException(
+            "There where errors when formatting files. Error count: " + failures);
+      }
     } catch (IOException exception) {
       throw new MojoFailureException(exception.getMessage());
     }
@@ -190,10 +198,10 @@ public abstract class AbstractFMT extends AbstractMojo {
     return pathname -> pathname.isDirectory() || pathname.getPath().matches(filesPathPattern);
   }
 
-  private void formatSourceFile(File file, Formatter formatter) {
+  private boolean formatSourceFile(File file, Formatter formatter) {
     if (file.isDirectory()) {
       getLog().info("File '" + file + "' is a directory. Skipping.");
-      return;
+      return true;
     }
 
     if (verbose) {
@@ -217,8 +225,10 @@ public abstract class AbstractFMT extends AbstractMojo {
         logNumberOfFilesProcessed();
       }
     } catch (FormatterException | IOException e) {
-      getLog().warn("Failed to format file '" + file + "'.", e);
+      getLog().error("Failed to format file '" + file + "'.", e);
+      return false;
     }
+    return true;
   }
 
   private void handleMissingDirectory(String directoryDisplayName, File directory)

--- a/src/main/java/com/coveo/AbstractFMT.java
+++ b/src/main/java/com/coveo/AbstractFMT.java
@@ -200,7 +200,9 @@ public abstract class AbstractFMT extends AbstractMojo {
 
   private boolean formatSourceFile(File file, Formatter formatter) {
     if (file.isDirectory()) {
-      getLog().info("File '" + file + "' is a directory. Skipping.");
+      if (verbose) {
+        getLog().debug("File '" + file + "' is a directory. Skipping.");
+      }
       return true;
     }
 

--- a/src/test/java/com/coveo/FMTTest.java
+++ b/src/test/java/com/coveo/FMTTest.java
@@ -1,10 +1,9 @@
 package com.coveo;
 
-import static com.google.common.truth.Truth.*;
+import static com.google.common.truth.Truth.assertThat;
 
 import java.io.File;
 import java.util.List;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.testing.MojoRule;
@@ -160,6 +159,12 @@ public class FMTTest {
   public void checkSucceedsWhenNotFormattedButIgnored() throws Exception {
     Check check =
         (Check) mojoRule.lookupConfiguredMojo(loadPom("check_notformatted_ignored"), CHECK);
+    check.execute();
+  }
+
+  @Test(expected = MojoFailureException.class)
+  public void checkFailsWhenFormattingFails() throws Exception {
+    Check check = (Check) mojoRule.lookupConfiguredMojo(loadPom("failed_formatting"), CHECK);
     check.execute();
   }
 

--- a/src/test/resources/failed_formatting/pom.xml
+++ b/src/test/resources/failed_formatting/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugin.my.unit</groupId>
+    <artifactId>project-to-test</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Test MyMojo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/failed_formatting/src/main/java/HelloWorld1.java
+++ b/src/test/resources/failed_formatting/src/main/java/HelloWorld1.java
@@ -1,0 +1,25 @@
+package notestsource.src.main.java;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+// force non-contiguous imports
+import javax.annotations.Nullable;
+import static com.google.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+public class HelloWorld1 {
+
+  <T> void check(@Nullable List<T> x) {
+    Preconditions.checkNodeNull(x);
+  }
+
+  void f() {
+    List<String> xs = null;
+    assertThat(xs).isNull();
+    try {
+      check(xs);
+      fail();
+    } catch (NullPointerException e) {
+    }
+  }
+}


### PR DESCRIPTION
@malaporte this PR makes 2.9.x branch usable by reducing the verboseness over skipped directories (backport of a commit on master) and upgrades the version to 2.9.2. 
Would it be possible to push a release to the maven repos?